### PR TITLE
change beta text

### DIFF
--- a/components/datasets/card-item/component.tsx
+++ b/components/datasets/card-item/component.tsx
@@ -61,6 +61,7 @@ export const DatasetCardItem: FC<DatasetCardItemProps> = ({
           <h4 className="mt-2 text-rw-gray font-bold antialiased">
             {metadata?.[0]?.info?.name || dataset.name}
           </h4>
+          <p className="text-rw-gray text-xs">{dataset?.subtitle}</p>
           <button
             type="button"
             className={classnames({

--- a/components/sidebar/component.tsx
+++ b/components/sidebar/component.tsx
@@ -62,9 +62,6 @@ export const Sidebar: FC = () => {
           </a>
           !
         </p>
-        <p className="bg-rw-gray-4 p-4 text-xs rounded-sm">
-          Beta version: data still under review and subject to change.
-        </p>
         <div className="my-5">
           <DatasetCardList list={datasets} />
         </div>

--- a/data/datasets.json
+++ b/data/datasets.json
@@ -6,7 +6,7 @@
       "attributes": {
         "name": "[internal] Composite Land Cover Map 2020",
         "active": true,
-        "subtitle": "",
+        "subtitle": "(beta version)",
         "metadata": [
           {
             "id": "613f8f271f59a5001b0e2488",
@@ -132,7 +132,7 @@
       "attributes": {
         "name": "[internal] Composite Land Cover Map",
         "active": false,
-        "subtitle": "",
+        "subtitle": "(beta version)",
         "metadata": [
           {
             "id": "613f8f271f59a5001b0e2488",
@@ -349,7 +349,7 @@
       "attributes": {
         "name": "[internal] 2000-2020 Forest Height Change",
         "active": false,
-        "subtitle": "",
+        "subtitle": "(beta version)",
         "metadata": [
           {
             "id": "616f11c36cd78b001acc1b6e",
@@ -559,7 +559,7 @@
       "attributes": {
         "name": "[internal] Snow/Ice Change",
         "active": false,
-        "subtitle": "",
+        "subtitle": "(beta version)",
         "metadata": [
           {
             "id": "613f8f271f59a5001b0e2488",
@@ -650,7 +650,7 @@
       "attributes": {
         "name": "[internal] Built-Up Area Change",
         "active": false,
-        "subtitle": "",
+        "subtitle": "(beta version)",
         "metadata": [
           {
             "id": "613f8f271f59a5001b0e2488",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -63,12 +63,14 @@ export interface DatasetMetadata {
   name: string;
   description?: string;
   source?: string;
+  subtitle?: string;
   info: MetadataInfo;
 }
 export interface Dataset {
   id: string;
   active?: boolean;
   name: string;
+  subtitle?: string;
   layer: Layer[];
   widget: Widget[];
   metadata: DatasetMetadata[];


### PR DESCRIPTION
The WRI Land and Carbon team asked to remove the umbrella "Beta version: data still under review and subject to change." at the top of the dataset list, and apply "(bata version)" labels to individual datasets where still relevant, now that several datasets have been published. This PR removes the umbrella beta version caution, and moves beta version text under the `subtitle` property of the dataset metadata objects.